### PR TITLE
updated empty strategy, included in run.py

### DIFF
--- a/UPISAS/strategies/empty_strategy.py
+++ b/UPISAS/strategies/empty_strategy.py
@@ -1,10 +1,17 @@
 from UPISAS.strategy import Strategy
 
-
+# This is a dummy strat for dingnet, with this it should be able to run, 
+# when you are ready to implement your own strategy do it here.
 class EmptyStrategy(Strategy):
-
     def analyze(self):
         return True
 
+# If this plan section is empty it will give an error:
+# ERROR:root:No complete JSON Schema provided for validation Keys misaligned
     def plan(self):
+        self.knowledge.plan_data = {
+        "items": [
+    
+        ]
+    }
         return True

--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
 from UPISAS.strategies.swim_reactive_strategy import ReactiveAdaptationManager
+from UPISAS.strategies.empty_strategy import EmptyStrategy
 from UPISAS.exemplar import Exemplar
 from UPISAS.exemplars.dingnet import Dingnet
 import signal
@@ -13,7 +14,7 @@ if __name__ == '__main__':
     time.sleep(3)
 
     try:
-        strategy = ReactiveAdaptationManager(exemplar)
+        strategy = EmptyStrategy(exemplar)
 
         strategy.get_monitor_schema()
         strategy.get_adaptation_options_schema()


### PR DESCRIPTION
basically updated the empty strategy which michael sent by mail earlier this week, and included that in run.py instead of the swim strategy. Now it doesnt say "something went wrong" unless you interrupt the terminal, it repeats the "adapt?" question in a loop like its supposed to